### PR TITLE
Fix compilation with flex 2.6.1

### DIFF
--- a/doxygen-1.8.1/src/code.l
+++ b/doxygen-1.8.1/src/code.l
@@ -3581,7 +3581,7 @@ void codeFreeScanner()
 extern "C" { // some bogus code to keep the compiler happy
   void codeYYdummy() { yy_flex_realloc(0,0); } 
 }
-#elif YY_FLEX_SUBMINOR_VERSION<33
+#elif (YY_FLEX_MAJOR_VERSION==2) && (YY_FLEX_MINOR_VERSION==5) && (YY_FLEX_SUBMINOR_VERSION<33)
 #error "You seem to be using a version of flex newer than 2.5.4 but older than 2.5.33. These versions do NOT work with doxygen! Please use version <=2.5.4 or >=2.5.33 or expect things to be parsed wrongly!"
 #endif
 

--- a/doxygen-1.8.1/src/commentscan.l
+++ b/doxygen-1.8.1/src/commentscan.l
@@ -999,7 +999,7 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
 					      // but we need to know the position in the input buffer where this 
 					      // rule matched.
 					      // for flex 2.5.33+ we should use YY_CURRENT_BUFFER_LVALUE
-#if YY_FLEX_MINOR_VERSION>=5 && YY_FLEX_SUBMINOR_VERSION>=33
+#if (YY_FLEX_MINOR_VERSION>5) || ((YY_FLEX_MINOR_VERSION==5) && (YY_FLEX_SUBMINOR_VERSION>=33))
 					      inputPosition=prevPosition + yy_bp - YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
 #else
 					      inputPosition=prevPosition + yy_bp - yy_current_buffer->yy_ch_buf;
@@ -1061,7 +1061,7 @@ RCSTAG    "$"{ID}":"[^\n$]+"$"
                                           g_memberGroupHeader.resize(0);
 					  parseMore=TRUE;
                                           needNewEntry = TRUE;
-#if YY_FLEX_MINOR_VERSION>=5 && YY_FLEX_SUBMINOR_VERSION>=33
+#if (YY_FLEX_MINOR_VERSION>5) || ((YY_FLEX_MINOR_VERSION==5) && (YY_FLEX_SUBMINOR_VERSION>=33))
 				          inputPosition=prevPosition + yy_bp - YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + strlen(yytext);
 #else
 				          inputPosition=prevPosition + yy_bp - yy_current_buffer->yy_ch_buf + strlen(yytext);

--- a/doxygen-1.8.1/src/fortrancode.l
+++ b/doxygen-1.8.1/src/fortrancode.l
@@ -1099,7 +1099,7 @@ void parseFortranCode(CodeOutputInterface &od,const char *className,const QCStri
 extern "C" { // some bogus code to keep the compiler happy
   void fcodeYYdummy() { yy_flex_realloc(0,0); } 
 }
-#elif YY_FLEX_SUBMINOR_VERSION<33
+#elif (YY_FLEX_MAJOR_VERSION==2) && (YY_FLEX_MINOR_VERSION==5) && (YY_FLEX_SUBMINOR_VERSION<33)
 #error "You seem to be using a version of flex newer than 2.5.4 but older than 2.5.33. These versions do NOT work with doxygen! Please use version <=2.5.4 or >=2.5.33 or expect things to be parsed wrongly!"
 #else
 extern "C" { // some bogus code to keep the compiler happy

--- a/doxygen-1.8.1/src/pycode.l
+++ b/doxygen-1.8.1/src/pycode.l
@@ -1480,7 +1480,7 @@ void parsePythonCode(CodeOutputInterface &od,const char * /*className*/,
 extern "C" { // some bogus code to keep the compiler happy
   void pycodeYYdummy() { yy_flex_realloc(0,0); } 
 }
-#elif YY_FLEX_SUBMINOR_VERSION<33
+#elif (YY_FLEX_MAJOR_VERSION==2) && (YY_FLEX_MINOR_VERSION==5) && (YY_FLEX_SUBMINOR_VERSION<33)
 #error "You seem to be using a version of flex newer than 2.5.4. These are currently incompatible with 2.5.4, and do NOT work with doxygen! Please use version 2.5.4 or expect things to be parsed wrongly! A bug report has been submitted (#732132)."
 #endif
 

--- a/doxygen-1.8.1/src/vhdlcode.l
+++ b/doxygen-1.8.1/src/vhdlcode.l
@@ -1597,7 +1597,7 @@ void codeFreeVhdlScanner()
 extern "C" { // some bogus code to keep the compiler happy
   void vhdlcodeYYdummy() { yy_flex_realloc(0,0); } 
 }
-#elif YY_FLEX_SUBMINOR_VERSION<33
+#elif (YY_FLEX_MAJOR_VERSION==2) && (YY_FLEX_MINOR_VERSION==5) && (YY_FLEX_SUBMINOR_VERSION<33)
 #error "You seem to be using a version of flex newer than 2.5.4 but older than 2.5.33. These versions do NOT work with doxygen! Please use version <=2.5.4 or >=2.5.33 or expect things to be parsed wrongly!"
 #endif
 

--- a/doxygen-1.8.1/src/vhdlparser.y
+++ b/doxygen-1.8.1/src/vhdlparser.y
@@ -375,7 +375,7 @@ physical_literal_1   : /* empty */        { $$=""; }
 physical_literal_no_default : t_AbstractLit t_Identifier   { $$=$1+" "+$2; }
 
 idf_list : t_Identifier { $$=$1; }
-         | idf_list t_Comma t_Identifier { $$=$1+","+$3}
+         | idf_list t_Comma t_Identifier { $$=$1+","+$3; }
          ;
 
 /*------------------------------------------
@@ -463,7 +463,7 @@ entity_decl_2 : /* empty */  { $$=""; }
               | t_PORT { currP=VhdlDocGen::PORT; }  interf_list t_Semicolon  { currP=0; }
               ;
 entity_decl_1 :  /* empty */  { $$=""; }
-              | t_GENERIC { currP=VhdlDocGen::GENERIC;parse_sec=GEN_SEC} interf_list t_Semicolon{ currP=0;parse_sec=0; }
+              | t_GENERIC { currP=VhdlDocGen::GENERIC;parse_sec=GEN_SEC; } interf_list t_Semicolon{ currP=0;parse_sec=0; }
               | t_GENERIC error t_Semicolon{ currP=0; }
               ;
 
@@ -1054,7 +1054,7 @@ physical_type_definition_2: secondary_unit_decl  { $$=$1+"#"; }
 
 base_unit_decl: t_Identifier t_Semicolon { $$=$1; }
 
-secondary_unit_decl: t_Identifier t_EQSym physical_literal t_Semicolon { $$=$1+"="+$3 }
+secondary_unit_decl: t_Identifier t_EQSym physical_literal t_Semicolon { $$=$1+"="+$3; }
 
 unconstrained_array_definition: t_ARRAY t_LeftParen
                                 index_subtype_definition unconstrained_array_definition_1 t_RightParen t_OF
@@ -1066,8 +1066,8 @@ unconstrained_array_definition: t_ARRAY t_LeftParen
     }
 
 unconstrained_array_definition_1: { $$=""; }
-unconstrained_array_definition_1: unconstrained_array_definition_1 unconstrained_array_definition_2 { $$=$1+"  "+$2 }
-unconstrained_array_definition_2: t_Comma index_subtype_definition { $$=", "+$2 }
+unconstrained_array_definition_1: unconstrained_array_definition_1 unconstrained_array_definition_2 { $$=$1+"  "+$2; }
+unconstrained_array_definition_2: t_Comma index_subtype_definition { $$=", "+$2; }
 
 index_subtype_definition: mark t_RANGE t_Box { $$=$1+" range<> "; }
 


### PR DESCRIPTION
At several places in code the macros were used to to throw an error on
versions between 2.5.4 and 2.5.33, incorectly matching versions with
higher minor numbers.
